### PR TITLE
Init storageBackend before use it

### DIFF
--- a/excalidraw-app/index.tsx
+++ b/excalidraw-app/index.tsx
@@ -102,7 +102,7 @@ import { openConfirmModal } from "../src/components/OverwriteConfirm/OverwriteCo
 import { OverwriteConfirmDialog } from "../src/components/OverwriteConfirm/OverwriteConfirm";
 import Trans from "../src/components/Trans";
 
-import { storageBackend } from "./data/config";
+import { storageBackend, getStorageBackend } from "./data/config";
 
 polyfill();
 
@@ -390,6 +390,7 @@ const ExcalidrawWrapper = () => {
     };
 
     initializeScene({ collabAPI, excalidrawAPI }).then(async (data) => {
+      await getStorageBackend();
       loadImages(data, /* isInitialLoad */ true);
       initialStatePromiseRef.current.promise.resolve(data.scene);
     });


### PR DESCRIPTION
Thank you for the great changes.

I wanted a self-hosted Excalidraw, so I decided to debug it.
I found that `storageBackend` was `null`.
https://github.com/alswl/excalidraw/blob/fork/excalidraw-app/index.tsx#L356

Therefore, I made sure to initialize it by calling `getStorageBackend` before `loadImages`.

Please check it out.
