### PR TITLE
release: v0.18.0 fork b1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,12 @@
 !scripts/
 !tsconfig.json
 !yarn.lock
+!index.html
+!index.tsx
+!vite.config.ts
+!vitest.config.ts
+!excalidraw-app
+!launcher.py
 
 # keep (sub)sub directories at the end to exclude from explicit included
 # e.g. ./packages/excalidraw/{dist,node_modules}

--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,7 @@
-VITE_APP_BACKEND_V2_GET_URL=https://json-dev.excalidraw.com/api/v2/
-VITE_APP_BACKEND_V2_POST_URL=https://json-dev.excalidraw.com/api/v2/post/
+# VITE_APP_BACKEND_V2_GET_URL=https://json-dev.excalidraw.com/api/v2/
+# VITE_APP_BACKEND_V2_POST_URL=https://json-dev.excalidraw.com/api/v2/post/
+VITE_APP_BACKEND_V2_GET_URL=http://localhost:8080/api/v2/scenes/
+VITE_APP_BACKEND_V2_POST_URL=http://localhost:8080/api/v2/scenes/
 
 VITE_APP_LIBRARY_URL=https://libraries.excalidraw.com
 VITE_APP_LIBRARY_BACKEND=https://us-central1-excalidraw-room-persistence.cloudfunctions.net/libraries
@@ -48,3 +50,6 @@ UNWEjuqNMi/lwAErS9fFa2oJlWyT8U7zzv/5kQREkxZI6y9v0AF3qcbsy2731FnD
 s9ChJvOUW9toIab2gsIdrKW8ZNpu084ZFVKb6LNjvIXI1Se4oMTHeszXzNptzlot
 kdxxjOoaQMAyfljFSot1F1FlU6MQlag7UnFGvFjRHN1JI5q4K+n3a67DX+TMyRqS
 HQIDAQAB'
+
+# alswl/excalidraw-collbration
+VITE_APP_STORAGE_BACKEND=firebase

--- a/.env.development
+++ b/.env.development
@@ -53,3 +53,4 @@ HQIDAQAB'
 
 # alswl/excalidraw-collbration
 VITE_APP_STORAGE_BACKEND=firebase
+VITE_APP_HTTP_STORAGE_BACKEND_URL=http://localhost:3001/api/v2

--- a/.github/workflows/build-docker-fork.yml
+++ b/.github/workflows/build-docker-fork.yml
@@ -1,0 +1,13 @@
+name: Build Docker image Fork
+
+on:
+  push:
+    branches:
+      - release-fork
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: docker build -t excalidraw -f dynamic-env.Dockerfile .

--- a/.github/workflows/publish-docker-fork.yml
+++ b/.github/workflows/publish-docker-fork.yml
@@ -1,0 +1,26 @@
+name: Publish Docker Fork
+
+on:
+  push:
+    branches:
+      - release-fork
+
+jobs:
+  publish-docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: dynamic-env.Dockerfile
+          push: true
+          tags: alswl/excalidraw:latest

--- a/.github/workflows/publish-docker-tag.yml
+++ b/.github/workflows/publish-docker-tag.yml
@@ -1,0 +1,26 @@
+name: Publish Docker Tag
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish-docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: dynamic-env.Dockerfile
+          push: true
+          tags: alswl/excalidraw:${{ github.ref_name }}

--- a/README-alswl-fork.md
+++ b/README-alswl-fork.md
@@ -4,6 +4,7 @@ Using this fork to add some features that I need.
 
 - [x] Self-host backend
 - [x] Chinese font support
+- [x] Dockernized
 
 more description in [Self hosted online collaborative drawing platform Excalidraw | Log4D](https://en.blog.alswl.com/2022/10/self-hosted-excalidraw/) and [私有化在线协同画图平台 Excalidraw | Log4D](https://blog.alswl.com/2022/10/self-hosted-excalidraw/)
 
@@ -15,22 +16,25 @@ upstream(excalidraw/excalidraw):
 
 fork:
     master: last used upstream, it will be related with upstream release tag
-    fork: master + features branches
-    release/$(version)-$(build-version): based on upstream release tag, and merge with features
     feat/$(name): feature branch, maybe deleted
-    feat/$(name)-long-live: feature branch, will not be deleted, rebased with every latest master
+    feat/$(upstream-version)-$(name): feature branch, related to upstream version, rebased
     tmp/*: temporary branch, maybe deleted
+    $(upstream-version)-fork: # released tag
 ```
 
 ## Current active feature branch
 
+Long live features branch:
+
+- feat/env-dynamic-in-docker-container
+- feat/add-basic-http-backend
+- feat/chinese-font-fork-feat
+- feat/docs-long-live
+
+Deprecated features:
+
 - feat/chinese-font-fork-feat
 - feat/chinese-font-support (active)
   - for upstream
-  - feat/chinese-font (deprecated)
-  - feat/chinese-font-for-v0.12.0 (deprecated, merged to release)
 - feat/self-host-backend-origin
-  - feat/self-host-backend (deprecated)
-  - feat/self-host-new-pr-for-v0.12.0 (deprecated, merge to release)
   - feat/self-host-backend-origin-v0.14.2 (active)
-- feat/env-dynamic-in-docker-container

--- a/README-alswl-fork.md
+++ b/README-alswl-fork.md
@@ -1,0 +1,36 @@
+# Excalidraw(forked)
+
+Using this fork to add some features that I need.
+
+- [x] Self-host backend
+- [x] Chinese font support
+
+more description in [Self hosted online collaborative drawing platform Excalidraw | Log4D](https://en.blog.alswl.com/2022/10/self-hosted-excalidraw/) and [私有化在线协同画图平台 Excalidraw | Log4D](https://blog.alswl.com/2022/10/self-hosted-excalidraw/)
+
+## Branch management
+
+```
+upstream(excalidraw/excalidraw):
+    release tag
+
+fork:
+    master: last used upstream, it will be related with upstream release tag
+    fork: master + features branches
+    release/$(version)-$(build-version): based on upstream release tag, and merge with features
+    feat/$(name): feature branch, maybe deleted
+    feat/$(name)-long-live: feature branch, will not be deleted, rebased with every latest master
+    tmp/*: temporary branch, maybe deleted
+```
+
+## Current active feature branch
+
+- feat/chinese-font-fork-feat
+- feat/chinese-font-support (active)
+  - for upstream
+  - feat/chinese-font (deprecated)
+  - feat/chinese-font-for-v0.12.0 (deprecated, merged to release)
+- feat/self-host-backend-origin
+  - feat/self-host-backend (deprecated)
+  - feat/self-host-new-pr-for-v0.12.0 (deprecated, merge to release)
+  - feat/self-host-backend-origin-v0.14.2 (active)
+- feat/env-dynamic-in-docker-container

--- a/README-alswl-fork.md
+++ b/README-alswl-fork.md
@@ -3,33 +3,37 @@
 Using this fork to add some features that I need.
 
 - [x] Self-host backend
-- [x] Chinese font support
-- [x] Dockernized
+- [x] Better Dockernized
+- [x] Chinese font support (after v0.18.0, using official way to load font `xiaolai`)
 
 more description in [Self hosted online collaborative drawing platform Excalidraw | Log4D](https://en.blog.alswl.com/2022/10/self-hosted-excalidraw/) and [私有化在线协同画图平台 Excalidraw | Log4D](https://blog.alswl.com/2022/10/self-hosted-excalidraw/)
 
 ## Branch management
 
 ```
-upstream(excalidraw/excalidraw):
-    release tag
+Branches:
 
-fork:
-    master: last used upstream, it will be related with upstream release tag
-    feat/$(name): feature branch, maybe deleted
-    feat/$(upstream-version)-$(name): feature branch, related to upstream version, rebased
-    tmp/*: temporary branch, maybe deleted
-    $(upstream-version)-fork: # released tag
+master: last used upstream, it will be related with upstream release tag
+feat/$(name): feature branch, maybe deleted
+feat/$(upstream-version)-$(name): feature branch, related to upstream version, rebased
+tmp/*: temporary branch, maybe deleted
+
+Tags:
+
+$(upstream-version)-fork: # released tag
 ```
 
 ## Current active feature branch
 
-Long live features branch:
+Long live features branch (since v0.18.0):
 
+- feat/http-backend
 - feat/env-dynamic-in-docker-container
-- feat/add-basic-http-backend
-- feat/chinese-font-fork-feat
-- feat/docs-long-live
+- feat/fork-docs
+
+Archived:
+
+- feat/chinese-font-fork-feat (archived)
 
 Deprecated features:
 

--- a/dynamic-env.Dockerfile
+++ b/dynamic-env.Dockerfile
@@ -1,0 +1,71 @@
+FROM node:18 AS build
+
+ARG CHINA_MIRROR=false
+
+# enable china mirror
+RUN if [[ "$CHINA_MIRROR" = "true" ]] ; then \
+    echo "Enable China Alpine Mirror" && \
+    sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories; \
+    fi
+
+RUN if [[ "$CHINA_MIRROR" = "true" ]] ; then \
+    echo "Enable China NPM Mirror" && \
+    npm install -g cnpm --registry=https://registry.npmmirror.com; \
+    npm config set registry https://registry.npmmirror.com; \
+    fi
+
+WORKDIR /opt/node_app
+
+COPY . .
+
+# do not ignore optional dependencies:
+# Error: Cannot find module @rollup/rollup-linux-x64-gnu
+RUN yarn --network-timeout 600000
+
+ARG NODE_ENV=production
+
+# disable webpack env loader, use dynamic env
+RUN sed -i 's/import.meta.env/window._env_/g' $(grep 'import.meta.env' -R -l --include "*.ts" --include "*.tsx" --exclude-dir node_modules .)
+RUN yarn build:app:docker
+
+FROM nginx:1.27-alpine
+
+ARG CHINA_MIRROR=false
+
+# enable china mirror
+RUN if [[ "$CHINA_MIRROR" = "true" ]] ; then \
+    echo "Enable China Alpine Mirror" && \
+    sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories; \
+    fi
+
+RUN apk update && apk add sed bash python3 py3-pip
+
+# enable china mirror
+RUN if [[ "$CHINA_MIRROR" = "true" ]] ; then \
+    echo "Enable China NPM Mirror" && \
+    pip3 config set global.index-url https://mirrors.aliyun.com/pypi/simple; \
+    fi
+
+RUN python3 -m venv /opt/node_app/.venv
+RUN . /opt/node_app/.venv/bin/activate && pip3 install beautifulsoup4
+
+# env from upstream .env.production
+
+ENV VITE_APP_BACKEND_V2_GET_URL=https://json.excalidraw.com/api/v2/
+ENV VITE_APP_BACKEND_V2_POST_URL=https://json.excalidraw.com/api/v2/post/
+ENV VITE_APP_LIBRARY_URL=https://libraries.excalidraw.com
+ENV VITE_APP_LIBRARY_BACKEND=https://us-central1-excalidraw-room-persistence.cloudfunctions.net/libraries
+ENV VITE_APP_PORTAL_URL=https://portal.excalidraw.com
+ENV VITE_APP_PLUS_LP=https://plus.excalidraw.com
+ENV VITE_APP_PLUS_APP=https://app.excalidraw.com
+ENV VITE_APP_WS_SERVER_URL=""
+ENV VITE_APP_FIREBASE_CONFIG='{"apiKey":"AIzaSyAd15pYlMci_xIp9ko6wkEsDzAAA0Dn0RU","authDomain":"excalidraw-room-persistence.firebaseapp.com","databaseURL":"https://excalidraw-room-persistence.firebaseio.com","projectId":"excalidraw-room-persistence","storageBucket":"excalidraw-room-persistence.appspot.com","messagingSenderId":"654800341332","appId":"1:654800341332:web:4a692de832b55bd57ce0c1"}'
+ENV VITE_APP_DISABLE_TRACKING=""
+
+COPY --from=build /opt/node_app/excalidraw-app/build /usr/share/nginx/html
+COPY launcher.py /
+
+HEALTHCHECK CMD wget -q -O /dev/null http://localhost || exit 1
+EXPOSE 80
+
+CMD ["/opt/node_app/.venv/bin/python3", "/launcher.py", "/usr/share/nginx/html"]

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -467,6 +467,7 @@ const ExcalidrawWrapper = () => {
     };
 
     initializeScene({ collabAPI, excalidrawAPI }).then(async (data) => {
+      await getStorageBackend();
       loadImages(data, /* isInitialLoad */ true);
       initialStatePromiseRef.current.promise.resolve(data.scene);
     });

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -75,7 +75,7 @@ import {
 import { updateStaleImageStatuses } from "./data/FileManager";
 import { newElementWith } from "@excalidraw/excalidraw/element/mutateElement";
 import { isInitializedImageElement } from "@excalidraw/excalidraw/element/typeChecks";
-import { loadFilesFromFirebase } from "./data/firebase";
+import { getStorageBackend } from "./data/config";
 import {
   LibraryIndexedDBAdapter,
   LibraryLocalStorageMigrationAdapter,
@@ -396,7 +396,7 @@ const ExcalidrawWrapper = () => {
       return;
     }
 
-    const loadImages = (
+    const loadImages = async (
       data: ResolutionType<typeof initializeScene>,
       isInitialLoad = false,
     ) => {
@@ -429,18 +429,21 @@ const ExcalidrawWrapper = () => {
           }, [] as FileId[]) || [];
 
         if (data.isExternalScene) {
-          loadFilesFromFirebase(
-            `${FIREBASE_STORAGE_PREFIXES.shareLinkFiles}/${data.id}`,
-            data.key,
-            fileIds,
-          ).then(({ loadedFiles, erroredFiles }) => {
-            excalidrawAPI.addFiles(loadedFiles);
-            updateStaleImageStatuses({
-              excalidrawAPI,
-              erroredFiles,
-              elements: excalidrawAPI.getSceneElementsIncludingDeleted(),
+          const storageBackend = await getStorageBackend();
+          storageBackend
+            .loadFilesFromStorageBackend(
+              `${FIREBASE_STORAGE_PREFIXES.shareLinkFiles}/${data.id}`,
+              data.key,
+              fileIds,
+            )
+            .then(({ loadedFiles, erroredFiles }) => {
+              excalidrawAPI.addFiles(loadedFiles);
+              updateStaleImageStatuses({
+                excalidrawAPI,
+                erroredFiles,
+                elements: excalidrawAPI.getSceneElementsIncludingDeleted(),
+              });
             });
-          });
         } else if (isInitialLoad) {
           if (fileIds.length) {
             LocalData.fileStorage

--- a/excalidraw-app/data/StorageBackend.ts
+++ b/excalidraw-app/data/StorageBackend.ts
@@ -1,0 +1,45 @@
+import { SyncableExcalidrawElement } from ".";
+import { ExcalidrawElement, FileId } from "../../src/element/types";
+import { AppState, BinaryFileData } from "../../src/types";
+import Portal from "../collab/Portal";
+
+export interface StorageBackend {
+  isSaved: (portal: Portal, elements: readonly ExcalidrawElement[]) => boolean;
+  saveToStorageBackend: (
+    portal: Portal,
+    elements: readonly SyncableExcalidrawElement[],
+    appState: AppState,
+  ) => Promise<false | { reconciledElements: any }>;
+  loadFromStorageBackend: (
+    roomId: string,
+    roomKey: string,
+    socket: SocketIOClient.Socket | null,
+  ) => Promise<readonly ExcalidrawElement[] | null>;
+  saveFilesToStorageBackend: ({
+    prefix,
+    files,
+  }: {
+    prefix: string;
+    files: {
+      id: FileId;
+      buffer: Uint8Array;
+    }[];
+  }) => Promise<{
+    savedFiles: Map<FileId, true>;
+    erroredFiles: Map<FileId, true>;
+  }>;
+  loadFilesFromStorageBackend: (
+    prefix: string,
+    decryptionKey: string,
+    filesIds: readonly FileId[],
+  ) => Promise<{
+    loadedFiles: BinaryFileData[];
+    erroredFiles: Map<FileId, true>;
+  }>;
+}
+
+export interface StoredScene {
+  sceneVersion: number;
+  iv: Uint8Array;
+  ciphertext: ArrayBuffer;
+}

--- a/excalidraw-app/data/StorageBackend.ts
+++ b/excalidraw-app/data/StorageBackend.ts
@@ -1,7 +1,10 @@
-import { SyncableExcalidrawElement } from ".";
-import { ExcalidrawElement, FileId } from "@excalidraw/excalidraw/element/types";
-import { AppState, BinaryFileData } from "@excalidraw/excalidraw/types";
-import Portal from "../collab/Portal";
+import type { SyncableExcalidrawElement } from ".";
+import type {
+  ExcalidrawElement,
+  FileId,
+} from "@excalidraw/excalidraw/element/types";
+import type { AppState, BinaryFileData } from "@excalidraw/excalidraw/types";
+import type Portal from "../collab/Portal";
 import type { Socket } from "socket.io-client";
 
 export interface StorageBackend {
@@ -15,8 +18,8 @@ export interface StorageBackend {
     roomId: string,
     roomKey: string,
     socket: Socket | null,
-  ) => Promise<readonly ExcalidrawElement[] | null>;
-  saveFilesToStorageBackend: ({ 
+  ) => Promise<readonly SyncableExcalidrawElement[] | null>;
+  saveFilesToStorageBackend: ({
     prefix,
     files,
   }: {
@@ -34,6 +37,11 @@ export interface StorageBackend {
     loadedFiles: BinaryFileData[];
     erroredFiles: Map<FileId, true>;
   }>;
+  saveSceneForMigration: (
+    id: string,
+    name: string,
+    data: Blob,
+  ) => Promise<void>;
 }
 
 export interface StoredScene {

--- a/excalidraw-app/data/StorageBackend.ts
+++ b/excalidraw-app/data/StorageBackend.ts
@@ -1,7 +1,8 @@
 import { SyncableExcalidrawElement } from ".";
-import { ExcalidrawElement, FileId } from "../../src/element/types";
-import { AppState, BinaryFileData } from "../../src/types";
+import { ExcalidrawElement, FileId } from "@excalidraw/excalidraw/element/types";
+import { AppState, BinaryFileData } from "@excalidraw/excalidraw/types";
 import Portal from "../collab/Portal";
+import type { Socket } from "socket.io-client";
 
 export interface StorageBackend {
   isSaved: (portal: Portal, elements: readonly ExcalidrawElement[]) => boolean;
@@ -9,13 +10,13 @@ export interface StorageBackend {
     portal: Portal,
     elements: readonly SyncableExcalidrawElement[],
     appState: AppState,
-  ) => Promise<false | { reconciledElements: any }>;
+  ) => Promise<any>;
   loadFromStorageBackend: (
     roomId: string,
     roomKey: string,
-    socket: SocketIOClient.Socket | null,
+    socket: Socket | null,
   ) => Promise<readonly ExcalidrawElement[] | null>;
-  saveFilesToStorageBackend: ({
+  saveFilesToStorageBackend: ({ 
     prefix,
     files,
   }: {
@@ -24,10 +25,7 @@ export interface StorageBackend {
       id: FileId;
       buffer: Uint8Array;
     }[];
-  }) => Promise<{
-    savedFiles: Map<FileId, true>;
-    erroredFiles: Map<FileId, true>;
-  }>;
+  }) => Promise<any>;
   loadFilesFromStorageBackend: (
     prefix: string,
     decryptionKey: string,

--- a/excalidraw-app/data/config.ts
+++ b/excalidraw-app/data/config.ts
@@ -3,6 +3,7 @@ import {
   loadFilesFromFirebase,
   loadFromFirebase,
   saveFilesToFirebase,
+  saveSceneToFirebaseForMigration,
   saveToFirebase,
 } from "./firebase";
 import {
@@ -10,9 +11,10 @@ import {
   loadFilesFromHttpStorage,
   loadFromHttpStorage,
   saveFilesToHttpStorage,
+  saveSceneForMigration as saveSceneToHttpStorageForMigration,
   saveToHttpStorage,
 } from "./httpStorage";
-import { StorageBackend } from "./StorageBackend";
+import type { StorageBackend } from "./StorageBackend";
 
 const firebaseStorage: StorageBackend = {
   isSaved: isSavedToFirebase,
@@ -37,6 +39,7 @@ const firebaseStorage: StorageBackend = {
     };
   },
   loadFilesFromStorageBackend: loadFilesFromFirebase,
+  saveSceneForMigration: saveSceneToFirebaseForMigration,
 };
 
 const httpStorage: StorageBackend = {
@@ -45,6 +48,7 @@ const httpStorage: StorageBackend = {
   loadFromStorageBackend: loadFromHttpStorage,
   saveFilesToStorageBackend: saveFilesToHttpStorage,
   loadFilesFromStorageBackend: loadFilesFromHttpStorage,
+  saveSceneForMigration: saveSceneToHttpStorageForMigration,
 };
 
 const storageBackends = new Map<string, StorageBackend>()
@@ -58,7 +62,7 @@ export async function getStorageBackend() {
     return storageBackend;
   }
 
-  const storageBackendName = process.env.REACT_APP_STORAGE_BACKEND || "";
+  const storageBackendName = import.meta.env.VITE_APP_STORAGE_BACKEND || "";
 
   if (storageBackends.has(storageBackendName)) {
     storageBackend = storageBackends.get(storageBackendName) as StorageBackend;

--- a/excalidraw-app/data/config.ts
+++ b/excalidraw-app/data/config.ts
@@ -16,9 +16,26 @@ import { StorageBackend } from "./StorageBackend";
 
 const firebaseStorage: StorageBackend = {
   isSaved: isSavedToFirebase,
-  saveToStorageBackend: saveToFirebase,
+  saveToStorageBackend: async (portal, elements, appState) => {
+    // saveToFirebase returns either null or stored elements array; adapt to interface
+    const res = await saveToFirebase(portal, elements, appState);
+    if (!res) {
+      return false;
+    }
+    return { reconciledElements: res };
+  },
   loadFromStorageBackend: loadFromFirebase,
-  saveFilesToStorageBackend: saveFilesToFirebase,
+  saveFilesToStorageBackend: async ({ prefix, files }) => {
+    // saveFilesToFirebase returns arrays; convert to Maps per interface
+    const { savedFiles, erroredFiles } = await saveFilesToFirebase({
+      prefix,
+      files,
+    });
+    return {
+      savedFiles: new Map(savedFiles.map((id) => [id, true] as const)),
+      erroredFiles: new Map(erroredFiles.map((id) => [id, true] as const)),
+    };
+  },
   loadFilesFromStorageBackend: loadFilesFromFirebase,
 };
 

--- a/excalidraw-app/data/config.ts
+++ b/excalidraw-app/data/config.ts
@@ -1,0 +1,54 @@
+import {
+  isSavedToFirebase,
+  loadFilesFromFirebase,
+  loadFromFirebase,
+  saveFilesToFirebase,
+  saveToFirebase,
+} from "./firebase";
+import {
+  isSavedToHttpStorage,
+  loadFilesFromHttpStorage,
+  loadFromHttpStorage,
+  saveFilesToHttpStorage,
+  saveToHttpStorage,
+} from "./httpStorage";
+import { StorageBackend } from "./StorageBackend";
+
+const firebaseStorage: StorageBackend = {
+  isSaved: isSavedToFirebase,
+  saveToStorageBackend: saveToFirebase,
+  loadFromStorageBackend: loadFromFirebase,
+  saveFilesToStorageBackend: saveFilesToFirebase,
+  loadFilesFromStorageBackend: loadFilesFromFirebase,
+};
+
+const httpStorage: StorageBackend = {
+  isSaved: isSavedToHttpStorage,
+  saveToStorageBackend: saveToHttpStorage,
+  loadFromStorageBackend: loadFromHttpStorage,
+  saveFilesToStorageBackend: saveFilesToHttpStorage,
+  loadFilesFromStorageBackend: loadFilesFromHttpStorage,
+};
+
+const storageBackends = new Map<string, StorageBackend>()
+  .set("firebase", firebaseStorage)
+  .set("http", httpStorage);
+
+export let storageBackend: StorageBackend | null = null;
+
+export async function getStorageBackend() {
+  if (storageBackend) {
+    return storageBackend;
+  }
+
+  const storageBackendName = process.env.REACT_APP_STORAGE_BACKEND || "";
+
+  if (storageBackends.has(storageBackendName)) {
+    storageBackend = storageBackends.get(storageBackendName) as StorageBackend;
+  } else {
+    console.warn("No storage backend found, default to firebase");
+    storageBackend = firebaseStorage;
+  }
+
+  return storageBackend;
+}

--- a/excalidraw-app/data/firebase.ts
+++ b/excalidraw-app/data/firebase.ts
@@ -86,7 +86,7 @@ type FirebaseStoredScene = {
   ciphertext: Bytes;
 };
 
-const encryptElements = async (
+export const encryptElements = async (
   key: string,
   elements: readonly ExcalidrawElement[],
 ): Promise<{ ciphertext: ArrayBuffer; iv: Uint8Array }> => {
@@ -97,7 +97,7 @@ const encryptElements = async (
   return { ciphertext: encryptedBuffer, iv };
 };
 
-const decryptElements = async (
+export const decryptElements = async (
   data: FirebaseStoredScene,
   roomKey: string,
 ): Promise<readonly ExcalidrawElement[]> => {
@@ -310,4 +310,19 @@ export const loadFilesFromFirebase = async (
   );
 
   return { loadedFiles, erroredFiles };
+};
+
+export const saveSceneToFirebaseForMigration = async (
+  id: string,
+  name: string,
+  data: Blob,
+) => {
+  const storage = await loadFirebaseStorage();
+  const storageRef = ref(storage, `/migrations/scenes/${id}`);
+  await uploadBytes(storageRef, data, {
+    customMetadata: {
+      data: JSON.stringify({ version: 2, name }),
+      created: Date.now().toString(),
+    },
+  });
 };

--- a/excalidraw-app/data/httpStorage.ts
+++ b/excalidraw-app/data/httpStorage.ts
@@ -1,0 +1,293 @@
+// Inspired and partly copied from https://gitlab.com/kiliandeca/excalidraw-fork
+// MIT, Kilian Decaderincourt
+
+import { getSyncableElements, SyncableExcalidrawElement } from ".";
+import { MIME_TYPES } from "../../src/constants";
+import { decompressData } from "../../src/data/encode";
+import { encryptData, IV_LENGTH_BYTES } from "../../src/data/encryption";
+import { restoreElements } from "../../src/data/restore";
+import { getSceneVersion } from "../../src/element";
+import { ExcalidrawElement, FileId } from "../../src/element/types";
+import {
+  AppState,
+  BinaryFileData,
+  BinaryFileMetadata,
+  DataURL,
+} from "../../src/types";
+import Portal from "../collab/Portal";
+import { reconcileElements } from "../collab/reconciliation";
+import { decryptData } from "../../src/data/encryption";
+import { StoredScene } from "./StorageBackend";
+
+const HTTP_STORAGE_BACKEND_URL = process.env.REACT_APP_HTTP_STORAGE_BACKEND_URL;
+const SCENE_VERSION_LENGTH_BYTES = 4;
+
+// There is a lot of intentional duplication with the firebase file
+// to prevent modifying upstream files and ease futur maintenance of this fork
+
+const httpStorageSceneVersionCache = new WeakMap<
+  SocketIOClient.Socket,
+  number
+>();
+
+export const isSavedToHttpStorage = (
+  portal: Portal,
+  elements: readonly ExcalidrawElement[],
+): boolean => {
+  if (portal.socket && portal.roomId && portal.roomKey) {
+    const sceneVersion = getSceneVersion(elements);
+
+    return httpStorageSceneVersionCache.get(portal.socket) === sceneVersion;
+  }
+  // if no room exists, consider the room saved so that we don't unnecessarily
+  // prevent unload (there's nothing we could do at that point anyway)
+  return true;
+};
+
+export const saveToHttpStorage = async (
+  portal: Portal,
+  elements: readonly SyncableExcalidrawElement[],
+  appState: AppState,
+) => {
+  const { roomId, roomKey, socket } = portal;
+  if (
+    // if no room exists, consider the room saved because there's nothing we can
+    // do at this point
+    !roomId ||
+    !roomKey ||
+    !socket ||
+    isSavedToHttpStorage(portal, elements)
+  ) {
+    return false;
+  }
+
+  const sceneVersion = getSceneVersion(elements);
+  const getResponse = await fetch(
+    `${HTTP_STORAGE_BACKEND_URL}/rooms/${roomId}`,
+  );
+
+  if (!getResponse.ok && getResponse.status !== 404) {
+    return false;
+  }
+  if (getResponse.status === 404) {
+    const result: boolean = await saveElementsToBackend(
+      roomKey,
+      roomId,
+      [...elements],
+      sceneVersion,
+    );
+    if (result) {
+      return {
+        reconciledElements: null,
+      };
+    }
+    return false;
+  }
+  // If room already exist, we compare scene versions to check
+  // if we're up to date before saving our scene
+  const buffer = await getResponse.arrayBuffer();
+  const sceneVersionFromRequest = parseSceneVersionFromRequest(buffer);
+  if (sceneVersionFromRequest >= sceneVersion) {
+    return false;
+  }
+
+  const existingElements = await getElementsFromBuffer(buffer, roomKey);
+  const reconciledElements = getSyncableElements(
+    reconcileElements(elements, existingElements, appState),
+  );
+
+  const result: boolean = await saveElementsToBackend(
+    roomKey,
+    roomId,
+    reconciledElements,
+    sceneVersion,
+  );
+
+  if (result) {
+    httpStorageSceneVersionCache.set(socket, sceneVersion);
+    return {
+      reconciledElements: elements,
+    };
+  }
+  return false;
+};
+
+export const loadFromHttpStorage = async (
+  roomId: string,
+  roomKey: string,
+  socket: SocketIOClient.Socket | null,
+): Promise<readonly ExcalidrawElement[] | null> => {
+  const HTTP_STORAGE_BACKEND_URL =
+    process.env.REACT_APP_HTTP_STORAGE_BACKEND_URL;
+  const getResponse = await fetch(
+    `${HTTP_STORAGE_BACKEND_URL}/rooms/${roomId}`,
+  );
+
+  const buffer = await getResponse.arrayBuffer();
+  const elements = await getElementsFromBuffer(buffer, roomKey);
+
+  if (socket) {
+    httpStorageSceneVersionCache.set(socket, getSceneVersion(elements));
+  }
+
+  return restoreElements(elements, null);
+};
+
+const getElementsFromBuffer = async (
+  buffer: ArrayBuffer,
+  key: string,
+): Promise<readonly ExcalidrawElement[]> => {
+  // Buffer should contain both the IV (fixed length) and encrypted data
+  const sceneVersion = parseSceneVersionFromRequest(buffer);
+  const iv = new Uint8Array(
+    buffer.slice(
+      SCENE_VERSION_LENGTH_BYTES,
+      IV_LENGTH_BYTES + SCENE_VERSION_LENGTH_BYTES,
+    ),
+  );
+  const encrypted = buffer.slice(
+    IV_LENGTH_BYTES + SCENE_VERSION_LENGTH_BYTES,
+    buffer.byteLength,
+  );
+
+  return await decryptElements(
+    { sceneVersion, ciphertext: encrypted, iv },
+    key,
+  );
+};
+
+export const saveFilesToHttpStorage = async ({
+  prefix,
+  files,
+}: {
+  prefix: string;
+  files: { id: FileId; buffer: Uint8Array }[];
+}) => {
+  const erroredFiles = new Map<FileId, true>();
+  const savedFiles = new Map<FileId, true>();
+
+  const HTTP_STORAGE_BACKEND_URL =
+    process.env.REACT_APP_HTTP_STORAGE_BACKEND_URL;
+
+  await Promise.all(
+    files.map(async ({ id, buffer }) => {
+      try {
+        const payloadBlob = new Blob([buffer]);
+        const payload = await new Response(payloadBlob).arrayBuffer();
+        await fetch(`${HTTP_STORAGE_BACKEND_URL}/files/${id}`, {
+          method: "PUT",
+          body: payload,
+        });
+        savedFiles.set(id, true);
+      } catch (error: any) {
+        erroredFiles.set(id, true);
+      }
+    }),
+  );
+
+  return { savedFiles, erroredFiles };
+};
+
+export const loadFilesFromHttpStorage = async (
+  prefix: string,
+  decryptionKey: string,
+  filesIds: readonly FileId[],
+) => {
+  const loadedFiles: BinaryFileData[] = [];
+  const erroredFiles = new Map<FileId, true>();
+
+  //////////////
+  await Promise.all(
+    [...new Set(filesIds)].map(async (id) => {
+      try {
+        const HTTP_STORAGE_BACKEND_URL =
+          process.env.REACT_APP_HTTP_STORAGE_BACKEND_URL;
+        const response = await fetch(`${HTTP_STORAGE_BACKEND_URL}/files/${id}`);
+        if (response.status < 400) {
+          const arrayBuffer = await response.arrayBuffer();
+
+          const { data, metadata } = await decompressData<BinaryFileMetadata>(
+            new Uint8Array(arrayBuffer),
+            {
+              decryptionKey,
+            },
+          );
+
+          const dataURL = new TextDecoder().decode(data) as DataURL;
+
+          loadedFiles.push({
+            mimeType: metadata.mimeType || MIME_TYPES.binary,
+            id,
+            dataURL,
+            created: metadata?.created || Date.now(),
+          });
+        } else {
+          erroredFiles.set(id, true);
+        }
+      } catch (error: any) {
+        erroredFiles.set(id, true);
+        console.error(error);
+      }
+    }),
+  );
+  //////
+
+  return { loadedFiles, erroredFiles };
+};
+
+const saveElementsToBackend = async (
+  roomKey: string,
+  roomId: string,
+  elements: SyncableExcalidrawElement[],
+  sceneVersion: number,
+) => {
+  const { ciphertext, iv } = await encryptElements(roomKey, elements);
+
+  // Concatenate Scene Version, IV with encrypted data (IV does not have to be secret).
+  const numberBuffer = new ArrayBuffer(4);
+  const numberView = new DataView(numberBuffer);
+  numberView.setUint32(0, sceneVersion, false);
+  const sceneVersionBuffer = numberView.buffer;
+  const payloadBlob = await new Response(
+    new Blob([sceneVersionBuffer, iv.buffer, ciphertext]),
+  ).arrayBuffer();
+  const putResponse = await fetch(
+    `${HTTP_STORAGE_BACKEND_URL}/rooms/${roomId}`,
+    {
+      method: "PUT",
+      body: payloadBlob,
+    },
+  );
+
+  return putResponse.ok;
+};
+
+const parseSceneVersionFromRequest = (buffer: ArrayBuffer) => {
+  const view = new DataView(buffer);
+  return view.getUint32(0, false);
+};
+
+const decryptElements = async (
+  data: StoredScene,
+  roomKey: string,
+): Promise<readonly ExcalidrawElement[]> => {
+  const ciphertext = data.ciphertext;
+  const iv = data.iv;
+
+  const decrypted = await decryptData(iv, ciphertext, roomKey);
+  const decodedData = new TextDecoder("utf-8").decode(
+    new Uint8Array(decrypted),
+  );
+  return JSON.parse(decodedData);
+};
+
+const encryptElements = async (
+  key: string,
+  elements: readonly ExcalidrawElement[],
+): Promise<{ ciphertext: ArrayBuffer; iv: Uint8Array }> => {
+  const json = JSON.stringify(elements);
+  const encoded = new TextEncoder().encode(json);
+  const { encryptedBuffer, iv } = await encryptData(key, encoded);
+
+  return { ciphertext: encryptedBuffer, iv };
+};

--- a/excalidraw-app/data/index.ts
+++ b/excalidraw-app/data/index.ts
@@ -34,8 +34,8 @@ import {
   FILE_UPLOAD_MAX_BYTES,
   ROOM_ID_BYTES,
 } from "../app_constants";
+import { getStorageBackend } from "./config";
 import { encodeFilesForUpload } from "./FileManager";
-import { saveFilesToFirebase } from "./firebase";
 
 export type SyncableExcalidrawElement = OrderedExcalidrawElement &
   MakeBrand<"SyncableExcalidrawElement">;
@@ -316,7 +316,8 @@ export const exportToBackend = async (
       url.hash = `json=${json.id},${encryptionKey}`;
       const urlString = url.toString();
 
-      await saveFilesToFirebase({
+      const storageBackend = await getStorageBackend();
+      await storageBackend.saveFilesToStorageBackend({
         prefix: `/files/shareLinks/${json.id}`,
         files: filesToUpload,
       });

--- a/excalidraw-app/index.html
+++ b/excalidraw-app/index.html
@@ -214,7 +214,9 @@
     </header>
     <div id="root"></div>
     <script type="module" src="index.tsx"></script>
-    <% if (typeof PROD != 'undefined' && PROD == true) { %>
+    <% if (typeof PROD != 'undefined' && PROD == true &&
+    typeof VITE_APP_ENABLE_TRACKING != 'undefined' &&
+    VITE_APP_ENABLE_TRACKING == true) { %>
     <!-- 100% privacy friendly analytics -->
     <script>
       // need to load this script dynamically bcs. of iframe embed tracking

--- a/excalidraw-app/tests/collab.test.tsx
+++ b/excalidraw-app/tests/collab.test.tsx
@@ -26,6 +26,7 @@ vi.mock("../../excalidraw-app/data/firebase.ts", () => {
   const loadFromFirebase = async () => null;
   const saveToFirebase = () => {};
   const isSavedToFirebase = () => true;
+  const saveSceneToFirebaseForMigration = () => {};
   const loadFilesFromFirebase = async () => ({
     loadedFiles: [],
     erroredFiles: [],
@@ -41,6 +42,7 @@ vi.mock("../../excalidraw-app/data/firebase.ts", () => {
     isSavedToFirebase,
     loadFilesFromFirebase,
     saveFilesToFirebase,
+    saveSceneToFirebaseForMigration,
   };
 });
 

--- a/launcher.py
+++ b/launcher.py
@@ -1,0 +1,183 @@
+# launch excalidraw with dynamic envs
+# author: @alswl
+# usage:
+#
+# 1. modify nodejs process.env in src first
+# gsed -i 's/import.meta.env/window._env_/g' $(grep 'import.meta.env' -R -l src)
+# yarn build:app:docker
+#
+# 2. using env
+# export VITE_APP_BACKEND_V2_GET_URL=http://127.0.0.1:3000/api/v2/
+# export VITE_APP_BACKEND_V2_POST_URL=http://127.0.0.1:3000/api/v2/post/
+# export VITE_APP_LIBRARY_URL=https://libraries.excalidraw.com
+# export VITE_APP_LIBRARY_BACKEND=https://us-central1-excalidraw-room-persistence.cloudfunctions.net/libraries
+# export VITE_APP_PORTAL_URL=https://portal.excalidraw.com
+# export VITE_APP_PLUS_LP=https://plus.excalidraw.com
+# export VITE_APP_PLUS_APP=https://app.excalidraw.com
+
+# export VITE_APP_WS_SERVER_URL="http://127.0.0.1"
+# export VITE_APP_FIREBASE_CONFIG='{"apiKey":"AIzaSyAd15pYlMci_xIp9ko6wkEsDzAAA0Dn0RU","authDomain":"excalidraw-room-persistence.firebaseapp.com","databaseURL":"https://excalidraw-room-persistence.firebaseio.com","projectId":"excalidraw-room-persistence","storageBucket":"excalidraw-room-persistence.appspot.com","messagingSenderId":"654800341332","appId":"1:654800341332:web:4a692de832b55bd57ce0c1"}'
+# export VITE_APP_DISABLE_TRACKING=false
+# export VITE_APP_GOOGLE_ANALYTICS_ID=UA-387204-13
+# export VITE_APP_MATOMO_URL=https://excalidraw.matomo.cloud/
+# export VITE_APP_CDN_MATOMO_TRACKER_URL=//cdn.matomo.cloud/excalidraw.matomo.cloud/matomo.js
+# export VITE_APP_MATOMO_SITE_ID=1
+# export VITE_APP_PLUS_APP=https://app.excalidraw.com
+# alswl's fork version env
+# export VITE_APP_HTTP_STORAGE_BACKEND_URL=http://127.0.0.1:8081/api/v2
+# export VITE_APP_STORAGE_BACKEND=http
+#
+# 3. launch nginx, python launcher.py /usr/share/nginx/html
+
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+
+from bs4 import BeautifulSoup
+
+PATCH_BY = "x-patch-by"
+ALSWL_EXCALIDRAW = "alswl/excalidraw"
+
+default_envs = {
+    "NODE_ENV": "production",
+    "PUBLIC_URL": "",
+    "PKG_NAME": "@excalidraw/excalidraw",
+    "PKG_VERSION": "0.15.0",
+    "ANALYZER": "false",
+    "EXAMPLE": "false",
+}
+
+embed_envs = [
+    # embed
+    "NODE_ENV",
+    "PUBLIC_URL",
+    "PKG_NAME",
+    "PKG_VERSION",
+    "ANALYZER",
+    "EXAMPLE",
+]
+
+
+def get_env_or_default(name: str):
+    v = os.environ.get(name, "")
+    if v == "":
+        v = default_envs.get(name, "")
+    return v
+
+
+def get_envs():
+    envs = [key for key, value in os.environ.items()]
+    vite_apps = [key for key in envs if key.startswith("VITE_APP_")]
+    return vite_apps + embed_envs
+
+
+def gen_dot_env(root: str):
+    # gen .env in root
+
+    with open(os.path.join(root, ".env"), "w") as f:
+        for name in get_envs():
+            val = get_env_or_default(name)
+            f.write(f"{name}={val}\n")
+
+
+def gen_env_js(root: str):
+    code = "window._env_ = {"
+    for name in get_envs():
+        val = get_env_or_default(name)
+        code += f"{name}: '{val}',"
+    code += "}"
+
+    with open(os.path.join(root, "env.js"), "w") as f:
+        f.write(code)
+    return code
+
+
+def patch_index_html(root: str, script: str):
+    with open(os.path.join(root, "index.html"), "r") as f:
+        page = f.read()
+
+    with open(os.path.join(root, "index.origin.html"), "w") as f:
+        f.write(page)
+
+    soup = BeautifulSoup(page, "html.parser")
+    first = soup.find("script")
+    if first is None:
+        print("script not found")
+        sys.exit(1)
+    if first.has_attr(PATCH_BY) and first[PATCH_BY] == ALSWL_EXCALIDRAW:
+        return
+    new_script = soup.new_tag("script")
+    new_script.string = script
+    new_script[PATCH_BY] = ALSWL_EXCALIDRAW
+    first.insert_before(new_script)
+    with open(os.path.join(root, "index.html"), "w") as f:
+        f.write(soup.prettify())
+
+
+def exec_nginx():
+    cmd = ["nginx", "-g", "daemon off;"]
+    p = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+        # cmd, stdout=subprocess.PIPE,
+    )
+    try:
+        while True:
+            readline = p.stdout.readline()
+            try:
+                stdout = readline.decode("utf-8").strip()
+
+                if stdout:
+                    print(stdout)
+            except UnicodeDecodeError:
+                pass
+
+    except KeyboardInterrupt:
+        p.send_signal(signal.SIGINT)
+        p.wait()
+
+
+def patch_service_worker(root):
+    # search javascript in root and replace window._env_.PUBLIC_URL to real value
+    # 1. search js file
+    for root, dirs, files in os.walk(root):
+        for file in files:
+            if file.endswith(".js") or file.endswith(".js.map"):
+                path = os.path.join(root, file)
+                with open(path, "r") as f:
+                    code = f.read()
+                code = code.replace(
+                    "window._env_.PUBLIC_URL", f"'{get_env_or_default('PUBLIC_URL')}'"
+                )
+                with open(path, "w") as f:
+                    f.write(code)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    # add position arg
+    parser.add_argument("root", type=str, help="web root path")
+    args = parser.parse_args()
+
+    root = args.root
+    # check exist index.html
+    if not os.path.exists(os.path.join(root, "index.html")):
+        print("index.html not found")
+        sys.exit(1)
+
+    # gen .env not required in launcher
+    # gen_dot_env(root)
+    code = gen_env_js(root)
+    patch_index_html(root, code)
+    patch_service_worker(root)
+
+    exec_nginx()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/excalidraw/global.d.ts
+++ b/packages/excalidraw/global.d.ts
@@ -1,5 +1,7 @@
 interface Window {
   ClipboardItem: any;
+  // alswl: patch using window._env_
+  _env_: any | undefined;
   __EXCALIDRAW_SHA__: string | undefined;
   EXCALIDRAW_ASSET_PATH: string | string[] | undefined;
   EXCALIDRAW_EXPORT_SOURCE: string;

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "dynamic-env.Dockerfile"
+  },
+  "deploy": {
+    "numReplicas": 1,
+    "sleepApplication": false,
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
- **feat: add basic http backend**
- **feat: upgrade with excalidraw main**
- **docs: add readme for this fork repo**
- **docs: update fork branch management policy**
- **feat: excalidraw addapt to multi storage backend**
- **fix: Init storageBackend before use it (#32)**
- **feat: using python launcher to start nginx**
- **feat: railway**
- **docs: update with offical CJK**
- **don't load tracking scripts if tracking is disabled**
